### PR TITLE
Add a github action to compose the tileset

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,0 +1,59 @@
+# preforms CI builds using compose.py from
+# https://github.com/CleverRaven/Cataclysm-DDA
+#
+# This action is triggerd by any PR against the master branch as well
+# as on any push to the master branch itself
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: CI Build
+
+jobs:
+  build:
+    name: CI Build
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          apk add --no-cache musl-dev gcc vips-dev python3-dev zip
+          pip3 install pyvips
+
+      - name: Checkout Code
+        uses: actions/checkout@master
+
+      - name: Build
+        id: build
+        run: |
+          tilset_name=Cuteaclysm
+          mkdir build && cd build
+          wget https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py
+
+          mkdir gfx
+          ln -sT ../.. gfx/$tilset_name
+
+          python3 compose.py $tilset_name
+
+          artifact_name=$tilset_name-$(echo $GITHUB_SHA | cut -c -8)
+          tileset_dir=gfx/$tilset_name
+
+          mkdir $artifact_name
+          mv $tileset_dir/*.png            $artifact_name
+          mv $tileset_dir/tile_config.json $artifact_name
+          mv $tileset_dir/tileset.txt      $artifact_name
+
+          zip -r $artifact_name.zip $artifact_name
+
+          echo ::set-output name=artifact_name::$artifact_name
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.build.outputs.artifact_name }}.zip
+          path: build/${{ steps.build.outputs.artifact_name }}.zip


### PR DESCRIPTION
This action will run every time a commit is added to master as well as on every pull request opened targeting master.

It will compose the tileset, then upload a zip file containing the composed tileset that you can download and use in cataclsym.

Currently the build is failing due do some inconsistently sized sprites unfortunately, you should be able to see them in the log for the github action.