### PR TITLE
Fix cuteclysm composer workflow

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -3,6 +3,7 @@
 #
 # This action is triggerd by any PR against the master branch as well
 # as on any push to the master branch itself
+name: Cuteclysm composer
 
 on:
   push:
@@ -12,8 +13,6 @@ on:
     branches:
       - master
 
-name: CI Build
-
 jobs:
   build:
     name: CI Build
@@ -22,38 +21,34 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip
+          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@master
-
+        uses: actions/checkout@v2
       - name: Build
         id: build
         run: |
-          tilset_name=Cuteaclysm
           mkdir build && cd build
-          wget https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py
+          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          || echo "Error: Failed to get compose.py"
 
-          mkdir gfx
-          ln -sT ../.. gfx/$tilset_name
+          cd ..
 
-          python3 compose.py $tilset_name
+          python3 build/compose.py --use-all . build
 
-          artifact_name=$tilset_name-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=gfx/$tilset_name
+          artifact_name=Cuteclysm-$(echo $GITHUB_SHA | cut -c -8)
+          tileset_dir=build
 
           mkdir $artifact_name
           mv $tileset_dir/*.png            $artifact_name
           mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
-
-          zip -r $artifact_name.zip $artifact_name
+          mv ./tileset.txt                 $artifact_name
 
           echo ::set-output name=artifact_name::$artifact_name
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ steps.build.outputs.artifact_name }}.zip
-          path: build/${{ steps.build.outputs.artifact_name }}.zip
+          name: ${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}


### PR DESCRIPTION
Fixes the CI composer workflow for Cuteclysm.
Based on <https://github.com/I-am-Erk/CDDA-Tilesets/blob/master/.github/workflows/ci_build.yml>, <https://github.com/pixel-32/CDDA-tileset/pull/64>.
Results, workflow and artifacts can be seen here: <https://github.com/casswedson/CDDA-tileset/actions>, I am surprised this even works (this was strangely easy to fix, I might be missing something obvious) please make sure everything looks OK.
