### PR TITLE
Remove unused zip package

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code


### PR DESCRIPTION
Removing this package because it is not used anywhere and <https://github.com/actions/upload-artifact> already does some zip magic for us.
Running workflow can be found here: <https://github.com/casswedson/CDDA-tileset/actions>