### PR TITLE
feat: auto genereate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
+      - name: "Generate release notes"
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            /repos/pixel-32/CDDA-tileset/releases/generate-notes \
+            -f tag_name='${{ steps.generate_env_vars.outputs.tag_name }}' \
+            -f target_commitish='master' \
+            -q .body > CHANGELOG.md
       - name: Create release
         id: create_release
         uses: actions/create-release@main
@@ -61,8 +70,7 @@ jobs:
         with:
           tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
           release_name: ${{ steps.generate_env_vars.outputs.release_name }}
-          body: |
-            Full Changelog [${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }}](https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }})
+          body_path: ./CHANGELOG.md
           draft: false
           prerelease: false
 


### PR DESCRIPTION
A few days ago, I asked Fris how to make release notes this pretty <https://github.com/I-am-Erk/CDDA-Tilesets/releases/tag/2022-05-08>

Turns out it is a feature of the releases page, tho you have to do it by hand, fris also pointed me to some api docs that could explain how to automate this

pretty release notes are very desirable, the api docs are confusing, but I got it working after some time

see this release <https://github.com/casswedson/CDDA-tileset/releases/tag/2022-05-12-2311> generated by this commit https://github.com/casswedson/CDDA-tileset/commit/5d157eb5b88c739f307a0facacc8cce0eb313c78

This was very useful for figuring out what needed to be done
https://github.com/cli/cli/blob/trunk/.github/workflows/releases.yml

references:
https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release