### PR TITLE
fix: releaser authentication error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 12 * * sun'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release:
     name: Create Release


### PR DESCRIPTION
While testing this workflow in the context of a different fork of mine, I noticed the need to authenticate with github cli with:
```yml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
for some reason, https://github.com/pixel-32/CDDA-tileset/pull/117 worked on my fork with no authentication needed, I was my repo so I guess there is no need to, this repo isn't like my repo so I want to make sure this doesn't break when it runs in the context of this repo