### PR TITLE
fix: missing release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.generate_env_vars.outputs.TAG-NAME }}
-          release_name: ${{ steps.generate_env_vars.outputs.RELEASE-NAME }}
+          release_name: ${{ steps.generate_env_vars.outputs.RELEASE-TITLE }}
           body_path: ./CHANGELOG.md
           draft: false
           prerelease: false


### PR DESCRIPTION
a typo resulted on this release
https://github.com/pixel-32/CDDA-tileset/releases/tag/2022-10-30 missing a tile it should say "Cuteclysm release [tag]"

it looks like this:
![image](https://user-images.githubusercontent.com/58050969/198900273-295a4594-74a4-4f99-97be-337df56294d9.png)
it should look something like this:
![image](https://user-images.githubusercontent.com/58050969/198900283-d20b7fd1-3fea-45d1-b3b9-c0a981dd3ab7.png)
