### PR TITLE
Fix overmap sprites for dirt/rural road using new ids

### DIFF
--- a/pngs_overmap_32x32/roads/dirt_road.json
+++ b/pngs_overmap_32x32/roads/dirt_road.json
@@ -1,82 +1,33 @@
 [
-{ "id": "dirtroad1_aban1", "fg": "t_pavement_y_center" },
-{ "id": "dirtroad1_aban1_north", "fg": "t_pavement_y_center" },
-{ "id": "dirtroad2_aban1", "fg": "t_pavement_y_center" },
-{ "id": "dirtroad2_aban1_north", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_3way", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_3way_east", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_3way_forest", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_3way_forest_east", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_3way_west", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_forest", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_forest_north", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_north", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn1", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn1_forest", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn1_forest_west", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn_forest", "fg": "t_pavement_y_center" },
-{ "id": "dirt_road_turn_forest_north", "fg": "t_pavement_y_center" },
-{
-  "//": "not used yet?",
-  "id": ["dirt road", "dirt_road", "dirtroad"],
-  "multitile": true,
-  "fg": [
-    "t_pavement_y_unconnected"
-  ],
-  "bg": [],
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": [],
-      "fg": [
-        "t_pavement_y_center"
-      ]
-    },
-    {
-      "id": "corner",
-      "bg": [],
-      "fg": [
-        "t_pavement_y_corner_nw",
-        "t_pavement_y_corner_sw",
-        "t_pavement_y_corner_se",
-        "t_pavement_y_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": [],
-      "fg": [
-        "t_pavement_y_t_connection_n",
-        "t_pavement_y_t_connection_w",
-        "t_pavement_y_t_connection_s",
-        "t_pavement_y_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": [],
-      "fg": [
-        "t_pavement_y_edge_ns",
-        "t_pavement_y_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": [],
-      "fg": [
-        "t_pavement_y_end_piece_n",
-        "t_pavement_y_end_piece_w",
-        "t_pavement_y_end_piece_s",
-        "t_pavement_y_end_piece_e"
-      ]
-    },
-    {
-      "bg": [],
-      "id": "unconnected",
-      "fg": [
-        "t_pavement_y_unconnected"
-      ]
-    }
-  ]
-}]
+  {
+    "id": [ "rural_road", "rural_road_forest" ],
+    "multitile": true,
+    "fg": [ "t_pavement_y_unconnected" ],
+    "bg": [  ],
+    "additional_tiles": [
+      { "id": "center", "bg": [  ], "fg": [ "t_pavement_y_center" ] },
+      {
+        "id": "corner",
+        "bg": [  ],
+        "fg": [ "t_pavement_y_corner_nw", "t_pavement_y_corner_sw", "t_pavement_y_corner_se", "t_pavement_y_corner_ne" ]
+      },
+      {
+        "id": "t_connection",
+        "bg": [  ],
+        "fg": [
+          "t_pavement_y_t_connection_n",
+          "t_pavement_y_t_connection_e",
+          "t_pavement_y_t_connection_s",
+          "t_pavement_y_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": [  ], "fg": [ "t_pavement_y_edge_ns", "t_pavement_y_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": [  ],
+        "fg": [ "t_pavement_y_end_piece_n", "t_pavement_y_end_piece_w", "t_pavement_y_end_piece_s", "t_pavement_y_end_piece_e" ]
+      },
+      { "bg": [  ], "id": "unconnected", "fg": [ "t_pavement_y_unconnected" ] }
+    ]
+  }
+]

--- a/pngs_overmap_32x32/roads/dirt_road.json
+++ b/pngs_overmap_32x32/roads/dirt_road.json
@@ -1,52 +1,21 @@
-{
-  "id": [ "rural_road", "rural_road_forest" ],
-  "fg": "t_pavement_y_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pavement_y_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_pavement_y_corner_nw",
-        "t_pavement_y_corner_sw",
-        "t_pavement_y_corner_se",
-        "t_pavement_y_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_pavement_y_t_connection_n",
-        "t_pavement_y_t_connection_w",
-        "t_pavement_y_t_connection_s",
-        "t_pavement_y_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_pavement_y_edge_ns",
-        "t_pavement_y_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_pavement_y_end_piece_s",
-        "t_pavement_y_end_piece_e",
-        "t_pavement_y_end_piece_n",
-        "t_pavement_y_end_piece_w"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_pavement_y_unconnected",
-        "t_pavement_y_unconnected"
-      ]
-    }
-  ]
-}
+[
+  {
+    "id": [ "rural_road", "rural_road_forest" ],
+    "fg": "t_dirt_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_dirt_center" },
+      { "id": "corner", "fg": [ "t_dirt_corner_nw", "t_dirt_corner_sw", "t_dirt_corner_se", "t_dirt_corner_ne" ] },
+      {
+        "id": "t_connection",
+        "fg": [ "t_dirt_t_connection_n", "t_dirt_t_connection_w", "t_dirt_t_connection_s", "t_dirt_t_connection_e" ]
+      },
+      { "id": "edge", "fg": [ "t_dirt_edge_ns", "t_dirt_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "fg": [ "t_dirt_end_piece_s", "t_dirt_end_piece_e", "t_dirt_end_piece_n", "t_dirt_end_piece_w" ]
+      },
+      { "id": "unconnected", "fg": [ "t_dirt_unconnected", "t_dirt_unconnected" ] }
+    ]
+  }
+]

--- a/pngs_overmap_32x32/roads/dirt_road.json
+++ b/pngs_overmap_32x32/roads/dirt_road.json
@@ -1,33 +1,52 @@
-[
-  {
-    "id": [ "rural_road", "rural_road_forest" ],
-    "multitile": true,
-    "fg": [ "t_pavement_y_unconnected" ],
-    "bg": [  ],
-    "additional_tiles": [
-      { "id": "center", "bg": [  ], "fg": [ "t_pavement_y_center" ] },
-      {
-        "id": "corner",
-        "bg": [  ],
-        "fg": [ "t_pavement_y_corner_nw", "t_pavement_y_corner_sw", "t_pavement_y_corner_se", "t_pavement_y_corner_ne" ]
-      },
-      {
-        "id": "t_connection",
-        "bg": [  ],
-        "fg": [
-          "t_pavement_y_t_connection_n",
-          "t_pavement_y_t_connection_e",
-          "t_pavement_y_t_connection_s",
-          "t_pavement_y_t_connection_w"
-        ]
-      },
-      { "id": "edge", "bg": [  ], "fg": [ "t_pavement_y_edge_ns", "t_pavement_y_edge_ew" ] },
-      {
-        "id": "end_piece",
-        "bg": [  ],
-        "fg": [ "t_pavement_y_end_piece_n", "t_pavement_y_end_piece_w", "t_pavement_y_end_piece_s", "t_pavement_y_end_piece_e" ]
-      },
-      { "bg": [  ], "id": "unconnected", "fg": [ "t_pavement_y_unconnected" ] }
-    ]
-  }
-]
+{
+  "id": [ "rural_road", "rural_road_forest" ],
+  "fg": "t_pavement_y_unconnected",
+  "multitile": true,
+  "additional_tiles": [
+    {
+      "id": "center",
+      "fg": "t_pavement_y_center"
+    },
+    {
+      "id": "corner",
+      "fg": [
+        "t_pavement_y_corner_nw",
+        "t_pavement_y_corner_sw",
+        "t_pavement_y_corner_se",
+        "t_pavement_y_corner_ne"
+      ]
+    },
+    {
+      "id": "t_connection",
+      "fg": [
+        "t_pavement_y_t_connection_n",
+        "t_pavement_y_t_connection_w",
+        "t_pavement_y_t_connection_s",
+        "t_pavement_y_t_connection_e"
+      ]
+    },
+    {
+      "id": "edge",
+      "fg": [
+        "t_pavement_y_edge_ns",
+        "t_pavement_y_edge_ew"
+      ]
+    },
+    {
+      "id": "end_piece",
+      "fg": [
+        "t_pavement_y_end_piece_s",
+        "t_pavement_y_end_piece_e",
+        "t_pavement_y_end_piece_n",
+        "t_pavement_y_end_piece_w"
+      ]
+    },
+    {
+      "id": "unconnected",
+      "fg": [
+        "t_pavement_y_unconnected",
+        "t_pavement_y_unconnected"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I changed the dirt road ids in [#72431](https://github.com/CleverRaven/Cataclysm-DDA/pull/72431) which borked all the overmap tilesets. Fixed it then decided `t_pavement_y` looked a bit odd when the perfectly good `t_dirt` multitile exists, I'll happily revert that change to just fix them though if you don't like it.

Before it broke:
![image](https://github.com/pixel-32/CDDA-tileset/assets/45432782/ffde531b-4f87-4a7c-a64b-bc30bd750b67)
Current:
![image](https://github.com/pixel-32/CDDA-tileset/assets/45432782/e813a153-948e-41c0-b54a-ff6b038b0b02)
Result of PR, gravel(`t_railroad_rubble`) sprites also look nice:
![image](https://github.com/pixel-32/CDDA-tileset/assets/45432782/d02e497e-4f16-4aae-b279-c91b370a29b4)
